### PR TITLE
Remove requirement of JavaConversions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -33,7 +33,8 @@ libraryDependencies <++= (scalaVersion) { scalaVersion =>
     "org.codehaus.jackson" % "jackson-mapper-asl" % "1.8.0" % "compile",
     "org.scala-tools.testing" %% "scalacheck"         % scalaCheckVersion   % "test"    withSources(),
     "com.twitter"             % "finagle"             % "1.8.0"  % "compile"           intransitive(),
-    "com.twitter"             % "finagle-core"        % "1.8.0" % "compile"
+    "com.twitter"             % "finagle-core"        % "1.8.0" % "compile",
+    "org.scalaj"              %% "scalaj-collection" % "1.2"
   )
 }
 

--- a/src/main/scala/com/foursquare/slashem/QueryBuilder.scala
+++ b/src/main/scala/com/foursquare/slashem/QueryBuilder.scala
@@ -7,7 +7,7 @@ import com.foursquare.slashem.Ast._
 import java.util.ArrayList
 import java.util.concurrent.TimeUnit
 import net.liftweb.record.Record
-import scala.collection.JavaConversions._
+import scalaj.collection.Imports._
 
 // Phantom types
 /** Used for an Ordered query */
@@ -101,13 +101,23 @@ case class QueryBuilder[M <: Record[M], Ord, Lim, MM <: MinimumMatchType, Y, H <
   }
 
    /** Helper method for case class extraction */
-   private def getForField[F1,M <: Record[M]](f: SlashemField[F1,M], fName: String, doc: Pair[Map[String,Any],Option[Map[String,ArrayList[String]]]]): Option[F1] = {
-     if (doc._1.containsKey(fName)) f.valueBoxFromAny(doc._1.get(fName).get).toOption else None
+   private def getForField[F1,M <: Record[M]](f: SlashemField[F1,M],
+                                              fName: String,
+                                              doc: Pair[Map[String,Any],Option[Map[String,ArrayList[String]]]]): Option[F1] = {
+     val mainDoc = doc._1
+     mainDoc.get(fName) match {
+       case Some(v) => f.valueBoxFromAny(v).toOption
+       case _ => None
+     }
    }
    /** Helper method for case class extraction */
    private def getHighlightForField(fName: String, doc: Pair[Map[String,Any],Option[Map[String,ArrayList[String]]]]): List[String] = {
-     doc._2 match {
-       case Some(hl) => if (hl.containsKey(fName)) hl.get(fName).get.toList else  Nil
+     val hlDoc = doc._2
+     hlDoc match {
+       case Some(hl) => hl.get(fName) match {
+         case Some(v) => v.asScala.toList
+         case _ =>  Nil
+       }
        case _ => Nil
      }
    }

--- a/src/main/scala/com/foursquare/slashem/Schema.scala
+++ b/src/main/scala/com/foursquare/slashem/Schema.scala
@@ -249,7 +249,8 @@ trait SolrMeta[T <: Record[T]] extends SlashemMeta[T] {
         val doc = jdoc.asScala
         val hl = if (doc.contains("id") && rsr.highlighting != null) {
           val scalaHl = rsr.highlighting.asScala
-          scalaHl.get(doc.get("id").toString) match {
+          val key = doc.get("id").get.toString
+          scalaHl.get(key) match {
             case Some(v) => Some(v.asScala.toMap)
             case _ => None
           }

--- a/src/main/scala/com/foursquare/slashem/Schema.scala
+++ b/src/main/scala/com/foursquare/slashem/Schema.scala
@@ -38,7 +38,7 @@ import org.joda.time.DateTime
 import java.util.{ArrayList, HashMap}
 import java.lang.Integer
 import java.net.InetSocketAddress
-import scala.collection.JavaConversions._
+import scalaj.collection.Imports._
 
 
 case class SolrResponseException(code: Int, reason: String, solrName: String, query: String) extends RuntimeException {
@@ -74,7 +74,7 @@ case class Response[T <: Record[T],Y] (schema: T, creator: Option[Response.RawDo
                   matchingHighlights match {
                     case Some(mhl) if (mhl.contains(fname)) => {
                       field match {
-                        case f: SlashemField[_,_] => f.setHighlighted(mhl.get(fname).get.toList)
+                        case f: SlashemField[_,_] => f.setHighlighted(mhl.get(fname).get.asScala.toList)
                         case _ => None
                       }
                     }
@@ -245,11 +245,14 @@ trait SolrMeta[T <: Record[T]] extends SlashemMeta[T] {
       //Take the raw search result and make the type templated search result.
       val rawDocs = rsr.response.docs
       val rawHls = rsr.highlighting
-      val joinedDocs = rawDocs.map(doc => {
-        val hl = if (doc.contains("id") && rsr.highlighting != null
-                     && rsr.highlighting.contains(doc.get("id").toString)
-                   ) {
-          Some(rsr.highlighting.get(doc.get("id").toString).toMap)
+      val joinedDocs: Array[(Map[String,Any], Option[Map[String,java.util.ArrayList[String]]])] = rawDocs.map(jdoc => {
+        val doc = jdoc.asScala
+        val hl = if (doc.contains("id") && rsr.highlighting != null) {
+          val scalaHl = rsr.highlighting.asScala
+          scalaHl.get(doc.get("id").toString) match {
+            case Some(v) => Some(v.asScala.toMap)
+            case _ => None
+          }
         } else {
           None
         }
@@ -424,14 +427,18 @@ trait ElasticSchema[M <: Record[M]] extends SlashemSchema[M] {
     val hitCount = response.getHits().totalHits().toInt
     val docs: Array[(Map[String,Any], Option[Map[String,java.util.ArrayList[String]]])] = response.getHits().getHits().map(doc => {
       val m = doc.sourceAsMap()
-      val annotedMap = m.toMap ++ List("score" -> doc.score().toDouble)
+      val annotedMap = (m.asScala ++ List("score" -> doc.score().toDouble)).toMap
       val hlf = doc.getHighlightFields()
       if (hlf == null) {
         Pair(annotedMap,None)
       } else {
         Pair(annotedMap,
-             Some(doc.getHighlightFields()
-                  .mapValues(v => new ArrayList(v.getFragments().toList))
+             Some(doc.getHighlightFields().asScala
+                  .mapValues(v => {
+                    val fragments: Array[String] = v.getFragments()
+                    val fragmentList: List[String] = Nil++fragments
+                    new ArrayList(fragmentList.asJava) }
+                           )
                   .toMap))
       }
     })


### PR DESCRIPTION
Make conversions to/from Java types explicit and no longer use JavaConversions, instead use scalaj-collection conversions.
