### PR TITLE
Update gpg plugin.

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
 resolvers += Resolver.url("scalasbt", new URL("http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases"))  (Resolver.ivyStylePatterns)
 
-addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.5")
+addSbtPlugin("com.jsuereth" % "xsbt-gpg-plugin" % "0.6")


### PR DESCRIPTION
This a compatibility fix for sbt 0.11.3; version .5 of the gpg plugin cannot be resolved on 0.11.3.  .6 works on both 0.11.2 and 0.11.3.
