### PR TITLE
Term queries

### DIFF
--- a/src/main/scala/com/foursquare/slashem/Ast.scala
+++ b/src/main/scala/com/foursquare/slashem/Ast.scala
@@ -7,6 +7,7 @@ import org.elasticsearch.index.query.{FilterBuilder => ElasticFilterBuilder,
                                       QueryBuilder => ElasticQueryBuilder,
                                       QueryBuilders => EQueryBuilders,
                                       QueryStringQueryBuilder}
+import scalaj.collection.Imports._
 
 /**
  * Abstract Syntax Tree used to represent queries.
@@ -407,6 +408,40 @@ object Ast {
     }
   }
 
+  /**
+   * A term query.  Used for queries that don't need to be analyzed
+   *
+   * By default, elasticFilter() will always be cached!
+   */
+  case class Term[T](query: Iterable[T], escaped: Boolean = true, cached: Boolean = true) extends Query[T] {
+    // hack for single term queries
+    def this(query: T) = this(List(query))
+    /** @inheritdoc */
+    //def extend() = throw new UnimplementedException("Slashem does not support Term queries Solr")
+    def extend(): String = {
+      escaped match {
+        case true => {'"' + escape(query.toString) + '"'}
+        case false => '"' + query.toString + '"'
+      }
+    }
+    /** @inheritdoc */
+    def elasticExtend(qf: List[WeightedField], pf: List[PhraseWeightedField], mm: Option[String]): ElasticQueryBuilder = {
+      val fieldName = qf.head.fieldName
+      val weight = qf.head.weight.toFloat
+      query match {
+        case term::Nil => EQueryBuilders.termQuery(fieldName, term).boost(weight)
+        case terms => EQueryBuilders.termsQuery(fieldName, terms.asJava).boost(weight)
+      }
+    }
+    /** @inheritdoc */
+    override def elasticFilter(qf: List[WeightedField]): ElasticFilterBuilder = {
+      val fieldName = qf.head.fieldName
+      query match {
+        case term::Nil => EFilterBuilders.termFilter(fieldName, term).cache(cached)
+        case terms => EFilterBuilders.termsFilter(fieldName, terms.asJava).cache(cached)
+      }
+    }
+  }
 
   case class Range[T](q1: Query[T],q2: Query[T]) extends Query[T] {
     /** @inheritdoc */
@@ -487,7 +522,7 @@ object Ast {
   }
 
   /**
-   * Class representing clauses ANDed together
+   * Class representing queries ANDed together
    */
   case class And[T](queries: Query[T]*) extends Query[T] {
     /** @inheritdoc */
@@ -507,7 +542,7 @@ object Ast {
     }
   }
   /**
-   * Case class representing a list of clauses ORed together
+   * Case class representing a list of queries ORed together
    */
   case class Or[T](queries: Query[T]*) extends Query[T] {
     /** @inheritdoc */

--- a/src/main/scala/com/foursquare/slashem/Ast.scala
+++ b/src/main/scala/com/foursquare/slashem/Ast.scala
@@ -421,8 +421,12 @@ object Ast {
     def extend(): String = {
       escaped match {
         // hack to fix wrapping the queries in a List()
-        case true => {'"' + escape(query.mkString("")) + '"'}
-        case false => '"' + query.toString + '"'
+        case true => {
+          val queries = query.map(q => {'"' + escape(q.toString) + '"'})
+          queries.mkString(" OR ")
+        }
+//        case true =>  {'"' + query.mkString("\" OR \"")
+        case false => '"' + query.mkString(" OR ") + '"'
       }
     }
     /** @inheritdoc */

--- a/src/main/scala/com/foursquare/slashem/Ast.scala
+++ b/src/main/scala/com/foursquare/slashem/Ast.scala
@@ -7,7 +7,6 @@ import org.elasticsearch.index.query.{FilterBuilder => ElasticFilterBuilder,
                                       QueryBuilder => ElasticQueryBuilder,
                                       QueryBuilders => EQueryBuilders,
                                       QueryStringQueryBuilder}
-import scalaj.collection.Imports._
 
 /**
  * Abstract Syntax Tree used to represent queries.
@@ -425,7 +424,6 @@ object Ast {
           val queries = query.map(q => {'"' + escape(q.toString) + '"'})
           queries.mkString(" OR ")
         }
-//        case true =>  {'"' + query.mkString("\" OR \"")
         case false => '"' + query.mkString(" OR ") + '"'
       }
     }

--- a/src/main/scala/com/foursquare/slashem/Ast.scala
+++ b/src/main/scala/com/foursquare/slashem/Ast.scala
@@ -420,7 +420,8 @@ object Ast {
     //def extend() = throw new UnimplementedException("Slashem does not support Term queries Solr")
     def extend(): String = {
       escaped match {
-        case true => {'"' + escape(query.toString) + '"'}
+        // hack to fix wrapping the queries in a List()
+        case true => {'"' + escape(query.mkString("")) + '"'}
         case false => '"' + query.toString + '"'
       }
     }

--- a/src/main/scala/com/foursquare/slashem/Ast.scala
+++ b/src/main/scala/com/foursquare/slashem/Ast.scala
@@ -430,7 +430,10 @@ object Ast {
       val weight = qf.head.weight.toFloat
       query match {
         case term::Nil => EQueryBuilders.termQuery(fieldName, term).boost(weight)
-        case terms => EQueryBuilders.termsQuery(fieldName, terms.asJava).boost(weight)
+        case terms => {
+          val moarTerms = terms.toSeq.map(_.toString)
+          EQueryBuilders.termsQuery(fieldName, moarTerms: _*).boost(weight)
+        }
       }
     }
     /** @inheritdoc */
@@ -438,7 +441,10 @@ object Ast {
       val fieldName = qf.head.fieldName
       query match {
         case term::Nil => EFilterBuilders.termFilter(fieldName, term).cache(cached)
-        case terms => EFilterBuilders.termsFilter(fieldName, terms.asJava).cache(cached)
+        case terms => {
+          val moarTerms = terms.toSeq.map(_.toString)
+          EFilterBuilders.termsFilter(fieldName, moarTerms: _*).cache(cached)
+        }
       }
     }
   }

--- a/src/main/scala/com/foursquare/slashem/Schema.scala
+++ b/src/main/scala/com/foursquare/slashem/Schema.scala
@@ -793,7 +793,6 @@ trait SolrSchema[M <: Record[M]] extends SlashemSchema[M] {
  */
 trait SlashemUnanalyzedField[V, M <: Record[M]] extends SlashemField[V, M] {
   self: Field[V, M] =>
-  import Helpers._
 
   override val unanalyzed = true
 }
@@ -802,6 +801,7 @@ trait SlashemField[V, M <: Record[M]] extends OwnedField[M] {
   self: Field[V, M] =>
   import Helpers._
 
+  // Override this value to produce unanalyzed queries!
   val unanalyzed = false
 
   def produceQuery(v: V): Query[V] = {
@@ -991,7 +991,7 @@ class SlashemPointField[T <: Record[T]](owner: T) extends PointField[T](owner) w
 class SlashemBooleanField[T <: Record[T]](owner: T) extends BooleanField[T](owner) with SlashemField[Boolean, T]
 class SlashemDateTimeField[T <: Record[T]](owner: T) extends JodaDateTimeField[T](owner) with SlashemField[DateTime, T]
 //More restrictive type so we can access the geohash
-class SlashemGeoField[T <: SlashemSchema[T]](owner: T) extends SlashemStringField[T](owner) {
+class SlashemGeoField[T <: SlashemSchema[T]](owner: T) extends SlashemUnanalyzedStringField[T](owner) {
   def inRadius(geoLat: Double, geoLong: Double, radiusInMeters: Int, maxCells: Int = owner.geohash.maxCells) = {
     val cellIds = owner.geohash.coverString(geoLat, geoLong, radiusInMeters, maxCells = maxCells)
     //If we have an empty cover we default to everything.

--- a/src/main/scala/com/foursquare/slashem/Schema.scala
+++ b/src/main/scala/com/foursquare/slashem/Schema.scala
@@ -439,8 +439,8 @@ trait SolrGeoHash {
 }
 //Default geohash, does nothing.
 object NoopSolrGeoHash extends SolrGeoHash {
-  def coverString (geoLat: Double, geoLong: Double, radiusInMeters: Int, maxCells: Int ): Seq[String] = List("pleaseUseaRealGeoHash")
-  def rectCoverString(topRight: (Double, Double), bottomLeft: (Double, Double), maxCells: Int = 0, minLevel: Int = 0, maxLevel: Int = 0): Seq[String] = List("pleaseUseaRealGeoHash")
+  def coverString (geoLat: Double, geoLong: Double, radiusInMeters: Int, maxCells: Int ): Seq[String] = List("pleaseUseaRealGeoHash", "thisIsForFunctionalityTests")
+  def rectCoverString(topRight: (Double, Double), bottomLeft: (Double, Double), maxCells: Int = 0, minLevel: Int = 0, maxLevel: Int = 0): Seq[String] = List("pleaseUseaRealGeoHash", "thisIsForFunctionalityTests")
 }
 
 trait SlashemSchema[M <: Record[M]] extends Record[M] {
@@ -876,7 +876,10 @@ trait SlashemField[V, M <: Record[M]] extends OwnedField[M] {
 //Slashem field types
 class SlashemStringField[T <: Record[T]](owner: T) extends StringField[T](owner, 0) with SlashemField[String, T]
 /**
- * Field type that can be queried without analyzing whitespace.
+ * Field type that can be queried without analyzing.
+ *
+ * Ex: multi-value field or a whitespace tokenized field where
+ * search terms are always for a specific token.
  *
  * @see SlashemStringField
  */

--- a/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
+++ b/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
@@ -310,6 +310,17 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
   }
 
   @Test
+  def testUnanalyzed {
+    try {
+      val res1 = ESimplePanda where (_.termsfield eqs "termhit") fetch()
+      //val res2 = ESimplePanda where (_.termsfield in List("randomterm", "termhit")) fetch()
+      Assert.assertEquals(res1.response.results.length, 1)
+    } catch {
+      case e: Exception => e.printStackTrace()
+    }
+  }
+
+  @Test
   def testListFieldIn {
     val response1 = ESimplePanda where (_.favnums in List(2, 3, 4, 5)) fetch()
     val response2 = ESimplePanda where (_.favnums in List(99)) fetch()
@@ -394,6 +405,7 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
     val favnums1 = List(1, 2, 3, 4, 5).asJava
     val favnums2 = List(1, 2, 3, 4, 5).asJava
     val favnums3 = List(6, 7, 8, 9, 10).asJava
+    val terms1 = List("termhit", "nohit").asJava
     val nicknames1 = List("jerry", "dawg", "xzibit").asJava
     val nicknames2 = List("xzibit", "alvin").asJava
     val nicknames3 = List("alvin", "nathaniel", "joiner").asJava
@@ -407,6 +419,7 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
                                                                           .field("favnums", favnums1)
                                                                           .field("nicknames", nicknames1)
                                                                           .field("hugenums", hugenums1)
+                                                                          .field("termsfield", terms1)
                                                                           .endObject()
       ).execute()
     .actionGet();

--- a/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
+++ b/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
@@ -313,20 +313,26 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
   def testListFieldIn {
     val response1 = ESimplePanda where (_.favnums in List(2, 3, 4, 5)) fetch()
     val response2 = ESimplePanda where (_.favnums in List(99)) fetch()
+    val response3 = ESimplePanda where (_.termsfield in List("termhit", "lol")) fetch()
     Assert.assertEquals(response1.response.results.length, 2)
     Assert.assertEquals(response2.response.results.length, 0)
+    Assert.assertEquals(response3.response.results.length, 1)
   }
 
   @Test
   def testIntListFieldEmptyIn {
-    val response = ESimplePanda where (_.favnums in List()) fetch()
-    Assert.assertEquals(response.response.results.length, 0)
+    val response1 = ESimplePanda where (_.favnums in List()) fetch()
+    val response2 = ESimplePanda where (_.termsfield in List()) fetch()
+    Assert.assertEquals(response1.response.results.length, 0)
+    Assert.assertEquals(response2.response.results.length, 0)
   }
 
  @Test
   def testIntListFieldEmptyNin {
-    val response = ESimplePanda where (_.favnums nin List()) fetch()
-    Assert.assertEquals(response.response.results.length, 8)
+    val response1 = ESimplePanda where (_.favnums nin List()) fetch()
+    val response2 = ESimplePanda where (_.termsfield nin List()) fetch()
+    Assert.assertEquals(response1.response.results.length, 8)
+    Assert.assertEquals(response2.response.results.length, 8)
   }
 
   @Test
@@ -344,6 +350,11 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
     val ids2 = response2.response.oids
     // All three docs with favnums should be returned, none contain 99
     Assert.assertEquals(ids2.intersect(idsWithFavNums).length, 3)
+
+    val response3 = ESimplePanda where (_.termsfield nin List("termhit")) fetch()
+    val ids3 = response3.response.oids
+    // All three docs with favnums should be returned, none contain 99
+    Assert.assertEquals(ids3.intersect(idsWithFavNums).length, 2)
   }
 
   @Test

--- a/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
+++ b/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
@@ -347,18 +347,18 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
   }
 
   @Test
-  def testUnanalyzed {
-    try {
-      val res1 = ESimplePanda where (_.termsfield eqs "termhit") fetch()
-      val res2 = ESimplePanda where (_.termsfield in List("randomterm", "termhit")) fetch()
-      Assert.assertEquals(res1.response.results.length, 1)
-      Assert.assertEquals(res2.response.results.length, 1)
-    } catch {
-      case e: Exception => {
-        e.printStackTrace()
-        Assert.fail
-      }
-    }
+  def testTermQueries {
+    val res1 = ESimplePanda where (_.termsfield eqs "termhit") fetch()
+    val res2 = ESimplePanda where (_.termsfield in List("randomterm", "termhit")) fetch()
+    Assert.assertEquals(res1.response.results.length, 1)
+    Assert.assertEquals(res2.response.results.length, 1)
+  }
+
+  @Test
+  def testTermFilters {
+    // grab 2 results, filter to 1
+    val res1 = ESimplePanda where (_.hugenums contains 1L) filter(_.termsfield in List("termhit", "randomterm")) fetch()
+    Assert.assertEquals(res1.response.results.length, 1)
   }
 
   @Before

--- a/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
+++ b/src/test/scala/com/foursquare/slashem/ElasticQueryTest.scala
@@ -310,17 +310,6 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
   }
 
   @Test
-  def testUnanalyzed {
-    try {
-      val res1 = ESimplePanda where (_.termsfield eqs "termhit") fetch()
-      //val res2 = ESimplePanda where (_.termsfield in List("randomterm", "termhit")) fetch()
-      Assert.assertEquals(res1.response.results.length, 1)
-    } catch {
-      case e: Exception => e.printStackTrace()
-    }
-  }
-
-  @Test
   def testListFieldIn {
     val response1 = ESimplePanda where (_.favnums in List(2, 3, 4, 5)) fetch()
     val response2 = ESimplePanda where (_.favnums in List(99)) fetch()
@@ -355,6 +344,21 @@ class ElasticQueryTest extends SpecsMatchers with ScalaCheckMatchers {
     val ids2 = response2.response.oids
     // All three docs with favnums should be returned, none contain 99
     Assert.assertEquals(ids2.intersect(idsWithFavNums).length, 3)
+  }
+
+  @Test
+  def testUnanalyzed {
+    try {
+      val res1 = ESimplePanda where (_.termsfield eqs "termhit") fetch()
+      val res2 = ESimplePanda where (_.termsfield in List("randomterm", "termhit")) fetch()
+      Assert.assertEquals(res1.response.results.length, 1)
+      Assert.assertEquals(res2.response.results.length, 1)
+    } catch {
+      case e: Exception => {
+        e.printStackTrace()
+        Assert.fail
+      }
+    }
   }
 
   @Before

--- a/src/test/scala/com/foursquare/slashem/ElasticTest.scala
+++ b/src/test/scala/com/foursquare/slashem/ElasticTest.scala
@@ -18,6 +18,7 @@ class ESimplePanda extends ElasticSchema[ESimplePanda] {
   object favnums extends SlashemIntListField(this)
   object nicknames extends SlashemStringListField(this)
   object hugenums extends SlashemLongListField(this)
+  object termsfield extends SlashemUnanalyzedStringField(this)
 }
 
 object ESimpleGeoPanda extends ESimpleGeoPanda with ElasticMeta[ESimpleGeoPanda] {

--- a/src/test/scala/com/foursquare/slashem/QueryTest.scala
+++ b/src/test/scala/com/foursquare/slashem/QueryTest.scala
@@ -562,7 +562,7 @@ class QueryTest extends SpecsMatchers with ScalaCheckMatchers {
                         "qf" -> "text",
                         "qf" -> "ngram_name^0.2",
                         "qf" -> "tags^0.01",
-                        "fq" -> "geo_s2_cell_ids:(\"pleaseUseaRealGeoHash\")",
+                        "fq" -> "geo_s2_cell_ids:(\"pleaseUseaRealGeoHash\" OR \"thisIsForFunctionalityTests\")",
                         "tieBreaker" -> "0.2",
                         "fl" -> "id,name,userid,mayorid,category_id_0,popularity,decayedPopularity1,lat,lng,checkin_info,score,hasSpecial,address,crossstreet,city,state,zip,country,checkinCount,partitionedPopularity",
                         "bq" -> "name:(holden's hobohut)^10.0",
@@ -609,7 +609,7 @@ class QueryTest extends SpecsMatchers with ScalaCheckMatchers {
                         "qf" -> "text",
                         "qf" -> "ngram_name^0.2",
                         "qf" -> "tags^0.01",
-                        "fq" -> "geo_s2_cell_ids:(\"pleaseUseaRealGeoHash\")",
+                        "fq" -> "geo_s2_cell_ids:(\"pleaseUseaRealGeoHash\" OR \"thisIsForFunctionalityTests\")",
                         "tieBreaker" -> "0.2",
                         "fl" -> "id,name,userid,mayorid,category_id_0,popularity,decayedPopularity1,lat,lng,checkin_info,score,hasSpecial,address,crossstreet,city,state,zip,country,checkinCount,partitionedPopularity",
                         "bq" -> "name:(holden's hobohut)^10.0",
@@ -630,7 +630,7 @@ class QueryTest extends SpecsMatchers with ScalaCheckMatchers {
                         "q" -> "(DJ Hixxy)",
                         "start" -> "0",
                         "rows" -> "10",
-                        "fq" -> "geo_s2_cell_ids:(\"pleaseUseaRealGeoHash\")")
+                        "fq" -> "geo_s2_cell_ids:(\"pleaseUseaRealGeoHash\" OR \"thisIsForFunctionalityTests\")")
     Assert.assertEquals(Nil, ((qp.toSet &~ expected.toSet)).toList)
     Assert.assertEquals(Nil, (expected.toSet &~ qp.toSet).toList)
   }


### PR DESCRIPTION
This pull request introduces unanalyzed query types and fields that have the ability to be used as filter queries that are optionally cached in ElasticSearch.
